### PR TITLE
Fix to MarbleMelonTiny in KnownTechFixer.cs

### DIFF
--- a/DecorationsMod/Fixers/KnownTechFixer.cs
+++ b/DecorationsMod/Fixers/KnownTechFixer.cs
@@ -458,7 +458,7 @@ namespace DecorationsMod.Fixers
                             KnownTechFixer.AddNotification(techType, false, false, true);
                     }
                 }
-                else if (ConfigSwitcher.AddAirSeedsWhenDiscovered)
+                if (ConfigSwitcher.AddAirSeedsWhenDiscovered)
                 {
                     if (techType == CrafterLogicFixer.MarbleMelonTiny)
                     {


### PR DESCRIPTION
Modified line 461 from "else if" to "if"
This fixes an issue that made the 'MarbleMelonTiny' TechType appear as visible (though not selectable) in the Seeds Fabricator prior to being discovered if both AddWaterSeedsWhenDiscovered and AddAirSeedsWhenDiscovered are set to True.